### PR TITLE
Configure teslamate with cloudflare tunnel and traefik

### DIFF
--- a/apps/mytesla/2.0.0/data.yml
+++ b/apps/mytesla/2.0.0/data.yml
@@ -1,24 +1,45 @@
 additionalProperties:
   formFields:
-    # Tailscale 配置
+    # Cloudflare 配置
     - default: ""
-      envKey: TS_AUTHKEY
+      envKey: CLOUDFLARE_TUNNEL_TOKEN
       label:
-        en: Tailscale Auth Key
-        zh: Tailscale 认证密钥
-        zh-Hant: Tailscale 認證密鑰
+        en: Cloudflare Tunnel Token
+        zh: Cloudflare Tunnel 令牌
+        zh-Hant: Cloudflare Tunnel 令牌
       required: true
       rule: paramCommon
       type: password
     - default: ""
-      envKey: TS_TAILNET_NAME
+      envKey: CLOUDFLARE_DOMAIN
       label:
-        en: Tailscale Tailnet Name (e.g. your-name.ts.net)
-        zh: Tailscale Tailnet 名称 (例如 your-name.ts.net)
-        zh-Hant: Tailscale Tailnet 名稱 (例如 your-name.ts.net)
+        en: Domain (e.g. mytesla.example.com)
+        zh: 域名 (例如 mytesla.example.com)
+        zh-Hant: 域名 (例如 mytesla.example.com)
       required: true
       rule: paramCommon
       type: text
+
+    # Basic Auth 配置
+    - default: "admin"
+      envKey: BASIC_AUTH_USER
+      label:
+        en: Basic Auth Username
+        zh: Basic Auth 用户名
+        zh-Hant: Basic Auth 用戶名
+      required: true
+      rule: paramCommon
+      type: text
+    - default: ""
+      envKey: BASIC_AUTH_PASS
+      label:
+        en: Basic Auth Password
+        zh: Basic Auth 密码
+        zh-Hant: Basic Auth 密碼
+      random: true
+      required: true
+      rule: paramComplexity
+      type: password
 
     # TeslaMateAPI 配置
     - default: ""
@@ -77,33 +98,13 @@ additionalProperties:
       type: password
 
     # 端口配置
-    - default: 4000
+    - default: 80
       edit: true
-      envKey: PANEL_APP_PORT_HTTP
+      envKey: TRAEFIK_HTTP_PORT
       label:
-        en: TeslaMate Port
-        zh: TeslaMate 端口
-        zh-Hant: TeslaMate 埠
-      required: true
-      rule: paramPort
-      type: number
-    - default: 3000
-      edit: true
-      envKey: GRAFANA_PORT
-      label:
-        en: Grafana Port
-        zh: Grafana 端口
-        zh-Hant: Grafana 埠
-      required: true
-      rule: paramPort
-      type: number
-    - default: 8080
-      edit: true
-      envKey: API_PORT
-      label:
-        en: TeslaMateAPI Port
-        zh: TeslaMateAPI 端口
-        zh-Hant: TeslaMateAPI 埠
+        en: Traefik HTTP Port
+        zh: Traefik HTTP 端口
+        zh-Hant: Traefik HTTP 埠
       required: true
       rule: paramPort
       type: number

--- a/apps/mytesla/2.0.0/docker-compose.yml
+++ b/apps/mytesla/2.0.0/docker-compose.yml
@@ -1,40 +1,35 @@
 version: "3"
 
 services:
-  tailscale:
-    image: docker.coconutcode.cc/tailscale/tailscale:v1.86.2
-    container_name: ${CONTAINER_NAME}-tailscale
-    hostname: mytesla
-    environment:
-      - TS_AUTHKEY=${TS_AUTHKEY}
-      - TS_STATE_DIR=/var/lib/tailscale
-      - TS_SOCKET=/var/run/tailscale/tailscaled.sock
-    volumes:
-      - ./data/tailscale/state:/var/lib/tailscale:rw
-      - ./data/tailscale/socket:/var/run/tailscale
-      - /dev/net/tun:/dev/net/tun
-    cap_add:
-      - NET_ADMIN
-      - SYS_MODULE
+  # Cloudflare Tunnel for internal network penetration
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: ${CONTAINER_NAME}-cloudflared
     restart: unless-stopped
+    command: tunnel run
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on:
+      - traefik
 
+  # Traefik as unified gateway
   traefik:
     image: docker.coconutcode.cc/traefik:v3.5.0
     container_name: ${CONTAINER_NAME}-traefik
-    network_mode: service:tailscale
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./data/tailscale/state:/var/lib/tailscale:rw
-      - ./data/tailscale/socket:/var/run/tailscale
+    restart: unless-stopped
     command:
-      - --entrypoints.web.address=:80
-      - --entrypoints.websecure.address=:443
+      - --api.insecure=true
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
-      - --certificatesresolvers.myresolver.tailscale=true
-    restart: unless-stopped
-    depends_on:
-      - tailscale
+      - --entrypoints.web.address=:80
+      - --log.level=INFO
+    ports:
+      - "${TRAEFIK_HTTP_PORT:-80}:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./data/auth:/auth
+    labels:
+      - "traefik.enable=true"
 
   teslamate:
     image: docker.coconutcode.cc/gococonut/teslamate
@@ -49,23 +44,25 @@ services:
       - DATABASE_NAME=${TM_DB_NAME}
       - DATABASE_HOST=database
       - MQTT_HOST=mosquitto
-      - VIRTUAL_HOST=mytesla.${TS_TAILNET_NAME}
+      - VIRTUAL_HOST=${CLOUDFLARE_DOMAIN}
       - ENCRYPTION_KEY=${TM_ENCRYPTION_KEY}
       - TZ=${TZ}
-    ports:
-      - ${PANEL_APP_PORT_HTTP}:4000
+      - CHECK_ORIGIN=true
     volumes:
       - ./data/teslamate:/opt/app/import
     labels:
       - "traefik.enable=true"
-      - "traefik.port=4000"
-      - "traefik.http.routers.teslamate.rule=Host(`mytesla.${TS_TAILNET_NAME}`)"
-      - "traefik.http.routers.teslamate.entrypoints=websecure"
-      - "traefik.http.routers.teslamate.tls=true"
-      - "traefik.http.routers.teslamate.tls.certresolver=myresolver"
-      - "traefik.http.routers.teslamate-ws.rule=Host(`mytesla.${TS_TAILNET_NAME}`) && Path(`/live/websocket`)"
-      - "traefik.http.routers.teslamate-ws.entrypoints=websecure"
-      - "traefik.http.routers.teslamate-ws.tls="
+      - "traefik.http.services.teslamate.loadbalancer.server.port=4000"
+      # Basic auth middleware
+      - "traefik.http.middlewares.teslamate-auth.basicauth.usersfile=/auth/.htpasswd"
+      - "traefik.http.middlewares.teslamate-auth.basicauth.realm=TeslaMate"
+      # Router for main teslamate
+      - "traefik.http.routers.teslamate.rule=Host(`${CLOUDFLARE_DOMAIN}`)"
+      - "traefik.http.routers.teslamate.entrypoints=web"
+      - "traefik.http.routers.teslamate.middlewares=teslamate-auth"
+      # WebSocket router without auth
+      - "traefik.http.routers.teslamate-ws.rule=Host(`${CLOUDFLARE_DOMAIN}`) && Path(`/live/websocket`)"
+      - "traefik.http.routers.teslamate-ws.entrypoints=web"
 
   grafana:
     image: docker.coconutcode.cc/gococonut/grafana
@@ -82,20 +79,16 @@ services:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PW}
       - GF_AUTH_ANONYMOUS_ENABLED=false
-      - GF_SERVER_DOMAIN=mytesla.${TS_TAILNET_NAME}
-      - GF_SERVER_ROOT_URL=https://mytesla.${TS_TAILNET_NAME}/grafana
+      - GF_SERVER_DOMAIN=${CLOUDFLARE_DOMAIN}
+      - GF_SERVER_ROOT_URL=https://${CLOUDFLARE_DOMAIN}/grafana
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
-    ports:
-      - ${GRAFANA_PORT}:3000
     volumes:
       - ./data/grafana:/var/lib/grafana
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.grafana.rule=Host(`mytesla.${TS_TAILNET_NAME}`) && PathPrefix(`/grafana`)"
-      - "traefik.http.routers.grafana.entrypoints=websecure"
-      - "traefik.http.routers.grafana.tls=true"
-      - "traefik.http.routers.grafana.tls.certresolver=myresolver"
-      - "traefik.port=3000"
+      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+      - "traefik.http.routers.grafana.rule=Host(`${CLOUDFLARE_DOMAIN}`) && PathPrefix(`/grafana`)"
+      - "traefik.http.routers.grafana.entrypoints=web"
 
   teslamateapi:
     image: docker.coconutcode.cc/mytesla/teslamateapi:latest
@@ -113,15 +106,14 @@ services:
       - API_TOKEN=${API_TOKEN}
     volumes:
       - ./data/teslamateapi:/opt/app/data
-    ports:
-      - ${API_PORT}:8080
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.teslamateapi.rule=Host(`mytesla.${TS_TAILNET_NAME}`) && (Path(`/api`) || PathPrefix(`/api/`))"
-      - "traefik.http.routers.teslamateapi.entrypoints=websecure"
-      - "traefik.http.routers.teslamateapi.tls=true"
-      - "traefik.http.routers.teslamateapi.tls.certresolver=myresolver"
-      - "traefik.port=8080"
+      - "traefik.http.services.teslamateapi.loadbalancer.server.port=8080"
+      - "traefik.http.routers.teslamateapi.rule=Host(`${CLOUDFLARE_DOMAIN}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.teslamateapi.entrypoints=web"
+      # Strip /api prefix if needed
+      - "traefik.http.middlewares.teslamateapi-stripprefix.stripprefix.prefixes=/api"
+      - "traefik.http.routers.teslamateapi.middlewares=teslamateapi-stripprefix"
 
   database:
     image: docker.coconutcode.cc/postgres:17
@@ -142,3 +134,7 @@ services:
     volumes:
       - ./data/mosquitto/config:/mosquitto/config
       - ./data/mosquitto/data:/mosquitto/data
+
+networks:
+  default:
+    name: ${CONTAINER_NAME}-network

--- a/apps/mytesla/2.0.0/scripts/init.sh
+++ b/apps/mytesla/2.0.0/scripts/init.sh
@@ -7,8 +7,7 @@ mkdir -p ./data/postgres
 mkdir -p ./data/mosquitto/config
 mkdir -p ./data/mosquitto/data
 mkdir -p ./data/teslamateapi
-mkdir -p ./data/tailscale/state
-mkdir -p ./data/tailscale/socket
+mkdir -p ./data/auth
 
 # 设置目录权限
 chmod -R 755 ./data
@@ -18,5 +17,29 @@ chown -R 472:472 ./data/grafana 2>/dev/null || true
 
 # 为 TeslaMateAPI 设置权限
 chown -R 1000:1000 ./data/teslamateapi 2>/dev/null || true
+
+# 生成 Basic Auth 密码文件
+if [ ! -f ./data/auth/.htpasswd ]; then
+    if [ -n "$BASIC_AUTH_USER" ] && [ -n "$BASIC_AUTH_PASS" ]; then
+        # 安装 htpasswd 工具（如果不存在）
+        if ! command -v htpasswd &> /dev/null; then
+            if command -v apt-get &> /dev/null; then
+                apt-get update && apt-get install -y apache2-utils
+            elif command -v yum &> /dev/null; then
+                yum install -y httpd-tools
+            fi
+        fi
+        
+        # 生成 .htpasswd 文件
+        if command -v htpasswd &> /dev/null; then
+            htpasswd -cb ./data/auth/.htpasswd "$BASIC_AUTH_USER" "$BASIC_AUTH_PASS"
+            echo "Basic Auth 配置已生成"
+        else
+            echo "警告: 无法生成 Basic Auth 配置，htpasswd 工具未找到"
+        fi
+    else
+        echo "警告: BASIC_AUTH_USER 或 BASIC_AUTH_PASS 未设置"
+    fi
+fi
 
 echo "Mytesla 初始化完成"

--- a/apps/mytesla/README.md
+++ b/apps/mytesla/README.md
@@ -1,6 +1,6 @@
 # Mytesla
 
-Mytesla 是一个功能强大的特斯拉车辆数据自托管记录器，集成了 TeslaMate、Grafana 数据可视化和 TeslaMateAPI，支持 Tailscale 零配置 VPN 安全访问。
+Mytesla 是一个功能强大的特斯拉车辆数据自托管记录器，集成了 TeslaMate、Grafana 数据可视化和 TeslaMateAPI，支持通过 Cloudflare Tunnel 进行安全的内网穿透访问。
 
 ## 功能特性
 
@@ -10,7 +10,7 @@ Mytesla 是一个功能强大的特斯拉车辆数据自托管记录器，集成
 - 🚗 **多车辆支持**: 支持同时记录多辆特斯拉车辆
 - 📱 **Web 界面**: 提供友好的 Web 管理界面
 - 🌐 **API 接口**: 提供 TeslaMateAPI RESTful 接口
-- 🔐 **安全访问**: 集成 Tailscale VPN，支持安全的远程访问
+- 🔐 **安全访问**: 集成 Cloudflare Tunnel 内网穿透，支持 Basic Auth 认证
 
 ## 安装要求
 
@@ -20,96 +20,79 @@ Mytesla 是一个功能强大的特斯拉车辆数据自托管记录器，集成
 - MQTT 消息队列（内置，自动部署）
 - Grafana 数据可视化（内置，自动部署）
 - TeslaMateAPI RESTful 接口（内置，自动部署）
-- Tailscale VPN 客户端（内置，自动部署）
+- Cloudflare Tunnel（内置，自动部署）
 - Traefik 反向代理（内置，自动部署）
 
 ### 端口说明
-- **TeslaMate**: 默认端口 4000，用于 Web 管理界面
-- **Grafana**: 默认端口 3000，用于数据可视化仪表板
-- **TeslaMateAPI**: 默认端口 8080，用于 RESTful API 接口
+- **Traefik HTTP**: 默认端口 80，统一处理所有 HTTP 服务
 
 ## 首次配置
 
-### 1. 准备 Tailscale 配置
+### 1. 准备 Cloudflare Tunnel 配置
 
-在安装应用之前，您需要准备 Tailscale 相关配置：
+在安装应用之前，您需要准备 Cloudflare Tunnel 相关配置：
 
-1. **注册 Tailscale 账号**
-   - 访问 [Tailscale 官网](https://tailscale.com/) 注册账号
-   - 可以使用 Google、Microsoft 或 GitHub 账号登录
+1. **创建 Cloudflare 账号**
+   - 访问 [Cloudflare 官网](https://cloudflare.com/) 注册账号
+   - 添加您的域名到 Cloudflare
 
-2. **获取认证密钥**
-   - 登录 [Tailscale 管理控制台](https://login.tailscale.com/admin/settings/keys)
-   - 点击 "Generate auth key" 生成认证密钥
-   - ⚠️ **重要**: 密钥只显示一次，请妥善保存
+2. **创建 Cloudflare Tunnel**
+   - 登录 [Cloudflare Zero Trust Dashboard](https://one.dash.cloudflare.com/)
+   - 进入 Access → Tunnels
+   - 点击 "Create a tunnel" 创建新的隧道
+   - 记录生成的 Tunnel Token
 
-3. **获取 Tailnet 名称**
-   - 在 [Tailscale DNS 设置](https://login.tailscale.com/admin/dns) 页面
-   - 找到您的 Tailnet 域名 (例如: `your-name.ts.net`)
+3. **配置域名**
+   - 在 Tunnel 配置中添加 Public Hostname
+   - 设置您希望使用的域名 (例如: `mytesla.example.com`)
+   - Service 设置为 `http://traefik:80`
 
 ### 2. 安装应用
 
 在 1Panel 应用商店中找到 Mytesla，点击安装并填写以下必要配置：
 
-#### Tailscale 配置
-- **Tailscale Auth Key**: 从步骤1获取的认证密钥
-- **Tailscale Tailnet Name**: 您的 Tailnet 域名 (例如: `your-name.ts.net`)
+#### Cloudflare 配置
+- **Cloudflare Tunnel Token**: 从步骤1获取的隧道令牌
+- **Domain**: 您配置的域名 (例如: `mytesla.example.com`)
+
+#### Basic Auth 配置
+- **Basic Auth Username**: 访问 TeslaMate 的用户名
+- **Basic Auth Password**: 访问 TeslaMate 的密码
 
 #### API 安全配置
 - **API Token**: 系统会自动生成，用于 TeslaMateAPI 安全认证
 
 #### 其他配置
 - 数据库配置：系统会自动生成安全的随机密码
-- 端口配置：根据需要调整端口号
 - Grafana 管理员账号：设置 Grafana 的登录密码
 
 ### 3. 配置 TeslaMate
 
 安装完成后：
 
-1. **本地访问**: 访问 `http://你的服务器IP:4000` 进入 TeslaMate 管理界面
-2. **Tailscale 访问**: 访问 `https://mytesla.你的Tailnet名称` (需要设备已连接 Tailscale)
+1. **通过域名访问**: 访问 `https://您的域名` 进入 TeslaMate 管理界面
+2. 输入 Basic Auth 用户名和密码
 3. 按照界面提示进行特斯拉账号授权
 4. 添加您的特斯拉车辆
 
 ### 4. 访问 Grafana 仪表板
 
-1. **本地访问**: 访问 `http://你的服务器IP:3000`
-2. **Tailscale 访问**: 访问 `https://mytesla.你的Tailnet名称/grafana`
-3. 使用安装时设置的管理员账号登录
-4. 浏览预配置的仪表板查看车辆数据
-
-### 5. 配置 Tailscale 客户端访问
-
-要从其他设备访问您的 Mytesla 服务：
-
-1. 在您的手机、电脑等设备上安装 [Tailscale 客户端](https://tailscale.com/download)
-2. 使用同一个 Tailscale 账号登录
-3. 连接成功后即可通过以下地址访问服务
-
-### 6. 设置 Tailscale 节点不过期
-
-⚠️ **重要步骤**: 
-
-1. 访问 [Tailscale 设备管理](https://login.tailscale.com/admin/machines)
-2. 找到名为 `mytesla` 的节点
-3. 点击设置，选择 "Disable key expiry"
-4. 这样可以防止节点过期导致服务无法访问
+1. **通过域名访问**: 访问 `https://您的域名/grafana`
+2. 使用安装时设置的管理员账号登录
+3. 浏览预配置的仪表板查看车辆数据
 
 ## 访问地址总览
 
 安装完成后，请记录以下访问地址，这些信息在配置 Mytesla.cc 时会用到：
 
-### 🌐 通过 Tailscale 访问 (推荐)
-- **TeslaMate 主界面**: `https://mytesla.你的Tailnet名称`
-- **Grafana 仪表板**: `https://mytesla.你的Tailnet名称/grafana`
-- **API 接口**: `https://mytesla.你的Tailnet名称/api`
-- **API 测试**: `https://mytesla.你的Tailnet名称/api/ping`
+### 🌐 通过域名访问 (推荐)
+- **TeslaMate 主界面**: `https://您的域名` (需要 Basic Auth)
+- **Grafana 仪表板**: `https://您的域名/grafana`
+- **API 接口**: `https://您的域名/api`
+- **API 测试**: `https://您的域名/api/ping`
 
 ### 🏠 本地网络访问
-- **TeslaMate 主界面**: `http://服务器IP:4000`
-- **Grafana 仪表板**: `http://服务器IP:3000`
-- **API 接口**: `http://服务器IP:8080`
+- **所有服务**: `http://服务器IP:80` (通过 Traefik 统一访问)
 
 ## 在 Mytesla.cc 中配置
 
@@ -118,7 +101,7 @@ Mytesla 是一个功能强大的特斯拉车辆数据自托管记录器，集成
 1. 访问 [https://mytesla.cc](https://mytesla.cc)
 2. 进入 Settings → TeslaMate 配置
 3. 填写以下信息：
-   - **API 地址**: `https://mytesla.你的Tailnet名称`
+   - **API 地址**: `https://您的域名`
    - **API Token**: 安装时生成的 API Token (在应用详情中可查看)
 4. 点击测试连接验证配置
 5. 配置成功后即可在 Mytesla.cc 中查看和管理您的特斯拉数据
@@ -128,34 +111,40 @@ Mytesla 是一个功能强大的特斯拉车辆数据自托管记录器，集成
 - ✅ 所有数据都存储在您的本地服务器上
 - ✅ 支持数据加密存储
 - ✅ API 接口使用 Token 进行安全认证
-- ✅ Tailscale 提供端到端加密连接
+- ✅ TeslaMate 支持 Basic Auth 认证保护
+- ✅ Cloudflare Tunnel 提供安全的内网穿透
 - ✅ 建议定期备份 PostgreSQL 数据库
 
 ## 故障排除
 
 ### 常见问题
 
-1. **无法通过 Tailscale 访问服务**
-   - 检查 Tailscale 服务是否正常运行：`docker logs mytesla-tailscale`
-   - 确认设备已连接到同一个 Tailnet
-   - 验证 Tailscale 节点未过期
+1. **无法通过域名访问服务**
+   - 检查 Cloudflare Tunnel 服务是否正常运行：`docker logs mytesla-cloudflared`
+   - 确认域名 DNS 解析正确
+   - 验证 Tunnel Token 配置正确
 
-2. **无法连接特斯拉账号**
+2. **Basic Auth 认证失败**
+   - 检查用户名和密码是否正确
+   - 确认 .htpasswd 文件生成成功
+   - 查看 Traefik 日志获取详细错误信息
+
+3. **无法连接特斯拉账号**
    - 检查网络连接
    - 确认特斯拉账号和密码正确
    - 查看 TeslaMate 日志获取详细错误信息
 
-3. **Grafana 无法显示数据**
+4. **Grafana 无法显示数据**
    - 确认数据库连接正常
    - 检查 TeslaMate 是否成功收集到数据
    - 验证 Grafana 数据源配置
 
-4. **API 接口无法访问**
+5. **API 接口无法访问**
    - 检查 TeslaMateAPI 服务状态
    - 验证 API Token 配置正确
    - 测试 API 连通性：访问 `/api/ping` 端点
 
-5. **服务启动失败**
+6. **服务启动失败**
    - 检查端口是否被占用
    - 确认数据库服务正常运行
    - 查看容器日志排查具体问题
@@ -170,7 +159,7 @@ docker ps
 docker logs mytesla                    # TeslaMate
 docker logs mytesla-grafana           # Grafana
 docker logs mytesla-teslamateapi      # TeslaMateAPI
-docker logs mytesla-tailscale         # Tailscale
+docker logs mytesla-cloudflared       # Cloudflare Tunnel
 docker logs mytesla-traefik           # Traefik
 ```
 
@@ -178,12 +167,12 @@ docker logs mytesla-traefik           # Traefik
 
 - [TeslaMate 官方文档](https://docs.teslamate.org/)
 - [Grafana 官方文档](https://grafana.com/docs/)
-- [Tailscale 官方文档](https://tailscale.com/kb/)
+- [Cloudflare Tunnel 文档](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/)
 - [Mytesla.cc 官网](https://mytesla.cc/)
 
 ## 注意事项
 
-- 首次启动可能需要几分钟时间初始化数据库和 Tailscale 连接
+- 首次启动可能需要几分钟时间初始化数据库和建立 Cloudflare Tunnel 连接
 - 建议在稳定的网络环境下运行
 - 定期更新到最新版本以获得最佳体验
-- 妥善保管 API Token 和 Tailscale 认证密钥
+- 妥善保管 API Token 和 Cloudflare Tunnel Token


### PR DESCRIPTION
Replace Tailscale with Cloudflare Tunnel and add Basic Auth for TeslaMate, using Traefik as a unified HTTP gateway.

---
<a href="https://cursor.com/background-agent?bcId=bc-003577a5-1363-45ba-9268-1645441d3625">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-003577a5-1363-45ba-9268-1645441d3625">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

